### PR TITLE
require() doesn't require correct file

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "weka"
   ],
   "license"             : "GPL-3.0+",
-  "main"                : "app.js",
+  "main"                : "lib/weka-lib.js",
   "name"                : "node-weka",
   "optionalDependencies": {},
   "repository"          : {


### PR DESCRIPTION
current build doesn't let you do the following `var weka = require('node-weka');`

this PR points the `main` file in `package.json` to the correct file 