### PR TITLE
Update weka jar version.

### DIFF
--- a/lib/weka-lib.js
+++ b/lib/weka-lib.js
@@ -58,7 +58,7 @@
   // Current version
   weka.VERSION = '0.0.8';
 
-  var sys = require('sys');
+  var sys = require('util');
   var exec = require('child_process').exec;
 
   var child;


### PR DESCRIPTION
This PR updates the `weka` jar version from `3.7.11 => 3.8.1`.
I also fixed an issue where importing `sys` instead of `util` was throwing deprecation warnings.

@MtnFranke 